### PR TITLE
feat: format release-please branch names in preview display

### DIFF
--- a/scripts/lib/preview-client.js
+++ b/scripts/lib/preview-client.js
@@ -2,7 +2,7 @@ import { CellarClient } from './cellar-client.js';
 import fs from 'node:fs';
 import { getCurrentAuthor, getCurrentCommit } from './git.js';
 import { BUILD_DIR, getAssetParts, getAssetPath, PREVIEW_DIR } from './paths.js';
-import { getEmoji, getSha256, highlight } from './utils.js';
+import { formatBranchName, getEmoji, getSha256, highlight } from './utils.js';
 import dedent from 'dedent';
 
 /**
@@ -274,7 +274,7 @@ export class PreviewClient {
   #renderPreview (preview) {
     return dedent`
       <tr>
-        <td><code class="branch"><a href="https://github.com/CleverCloud/clever-tools/tree/${preview.name}">${preview.name}</a></code></td>
+        <td><code class="branch"><a href="https://github.com/CleverCloud/clever-tools/tree/${preview.name}">${formatBranchName(preview.name)}</a></code></td>
         <td><code class="commit" title="${preview.commitId}"><a href="https://github.com/CleverCloud/clever-tools/commit/${preview.commitId}">${preview.commitId.substring(0, 8)}</a></code></td>
         <td class="right"><cc-datetime-relative datetime="${preview.updatedAt}">${preview.updatedAt}</cc-datetime-relative></td>
         <td><span>${preview.author}</span></td>

--- a/scripts/lib/preview-display.js
+++ b/scripts/lib/preview-display.js
@@ -3,7 +3,7 @@ import textTable from 'text-table';
 import stringLength from 'string-length';
 import fs from 'node:fs';
 import path from 'node:path';
-import { createTerminalLink, exec, getEmoji, getOs } from './utils.js';
+import { createTerminalLink, exec, formatBranchName, getEmoji, getOs } from './utils.js';
 
 /**
  * @typedef {import('./preview-client.types.d.ts').Preview} Preview
@@ -96,7 +96,7 @@ export class PreviewDisplay {
       const isDeleted = action === 'delete';
 
       const row = [
-        styleText('yellow', p.name),
+        styleText('yellow', formatBranchName(p.name)),
         styleText('blue', p.commitId.substring(0, 8)),
         date,
         time,
@@ -222,7 +222,7 @@ export class PreviewDisplay {
       const isDeleted = action === 'delete';
 
       const row = [
-        styleText('yellow', p.name),
+        styleText('yellow', formatBranchName(p.name)),
         styleText('blue', p.commitId.substring(0, 8)),
         date,
         time,

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -15,6 +15,18 @@ export function getVersion (rawVersion) {
 }
 
 /**
+ * Formats a branch name for display, truncating release-please branches.
+ * @param {string} branchName - The branch name to format
+ * @returns {string}
+ */
+export function formatBranchName (branchName) {
+  if (branchName.startsWith('release-please--branches')) {
+    return 'release-please…';
+  }
+  return branchName;
+}
+
+/**
  * Gets the current operating system in a normalized format.
  * Maps Node.js platform() values to simplified OS names.
  * @returns {'linux'|'macos'|'win'}


### PR DESCRIPTION
## Summary
- Add `formatBranchName` utility function to truncate long release-please branch names
- Display release-please branches as "release-please…" for better readability
- Update both preview client and display modules to use the new formatting

## Test plan
- [x] Verify branch name formatting works in preview displays
- [x] Confirm regular branch names remain unchanged
- [x] Check both terminal and web preview interfaces

🤖 Generated with [Claude Code](https://claude.ai/code)